### PR TITLE
Add tenor-tui as active project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This list is the single source of truth — none of the sibling repos carry thei
 | Sibling repo | Owns path | Notes |
 |---|---|---|
 | https://github.com/jayrav13/ruby-pure-greeks | `/ruby-pure-greeks/*` | Docs site for the `pure_greeks` Ruby gem. Source is `main` / `/docs`, Jekyll cayman theme. |
+| https://github.com/jayrav13/tenor-tui | `/tenor-tui/*` | Docs site for the `tenor-tui` Python package. Source is `gh-pages` branch, MkDocs Material, deployed by `.github/workflows/docs.yml` on every merge to `main`. |
 
 ## When to update this list
 

--- a/src/content/projects/tenor-tui.md
+++ b/src/content/projects/tenor-tui.md
@@ -1,0 +1,14 @@
+---
+name: "tenor-tui"
+blurb: "A terminal UI for browsing stock options chains. Live quotes, full chains with Greeks, named watchlists, and pluggable data providers (Yahoo, Tradier) — all keyboard-driven."
+year: 2026
+status: live
+links:
+  - label: "Docs"
+    url: "https://jayravaliya.com/tenor-tui/"
+  - label: "GitHub"
+    url: "https://github.com/jayrav13/tenor-tui"
+  - label: "PyPI"
+    url: "https://pypi.org/project/tenor-tui/"
+hasPage: false
+---


### PR DESCRIPTION
## Summary

Adds `tenor-tui` to the projects list, alongside `njtransit` and `pure_greeks`.

- New project entry: `src/content/projects/tenor-tui.md` (live, 2026, links to docs site / GitHub / PyPI)
- Sibling Pages registry update in `CLAUDE.md`: `jayrav13/tenor-tui` owns `/tenor-tui/*` (gh-pages branch, MkDocs Material)

Live at:
- Docs: https://jayravaliya.com/tenor-tui/
- PyPI: https://pypi.org/project/tenor-tui/
- Source: https://github.com/jayrav13/tenor-tui

## Test plan

- [x] `npm run build` succeeds
- [x] tenor-tui renders in the Projects section above Legacy
- [x] Link points at the live docs site

*Co-authored by Claude*