### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: npm
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `actions/upload-pages-artifact` v3 → v5, `actions/deploy-pages` v4 → v5.
- All four are the Node 24 lineages, clearing the [Node 20 on Actions runners deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) before the 2026-06-02 forced bump and 2026-09-16 removal.

## Compatibility note
`setup-node@v5` introduced auto-caching from `package.json`'s `packageManager` field; `v6` narrowed that to npm only. This workflow already passes `cache: npm` explicitly, so neither auto-detection change applies.

## Test plan
- [ ] Merge triggers a green deploy run with no Node-20 deprecation annotation.
- [ ] https://jayravaliya.com still loads.

Closes #3
