### PR TITLE
Add Dependabot config for github-actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the two ecosystems this repo uses (github-actions, npm), weekly, with `open-pull-requests-limit: 10` to match sibling-repo house style.
- Closes #7.

## Test plan
- [ ] Confirm the file lints (Dependabot validates on push and surfaces errors on the repo's Insights → Dependency graph → Dependabot tab).
- [ ] Within ~24h of merge, confirm Dependabot opens at least one PR (or reports "no updates available") on both ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)