### PR TITLE
Run build on PRs; keep deploy gated to push:main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,16 +3,13 @@ name: Deploy site to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -34,13 +31,18 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Adds `pull_request` to the deploy workflow's triggers so every PR runs `npm ci && npm run build` and surfaces a status check.
- Gates the `deploy` job and the `Upload Pages artifact` step on `github.event_name == 'push' && github.ref == 'refs/heads/main'` — PRs never deploy and never upload a Pages artifact.
- Moves `concurrency: group: pages` from the workflow level down to the `deploy` job. Otherwise, a PR build kicked off mid-deploy would share the `pages` group and cancel the in-flight production deploy.
- Closes #8.

## Test plan
- [ ] This PR itself should now show a "build" status check (the meta-test for the change).
- [ ] Confirm the `deploy` job is skipped on this PR (visible in the Checks tab).
- [ ] After merge, confirm the next push to `main` still deploys end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)